### PR TITLE
29 merge multiplane pipelines

### DIFF
--- a/.codeocean/datasets.json
+++ b/.codeocean/datasets.json
@@ -2,12 +2,12 @@
 	"version": 1,
 	"attached_datasets": [
 		{
-			"id": "35d1284e-4dfa-4ac3-9ba8-5ea1ae2fdaeb",
-			"mount": "2p_roi_classifier"
+			"id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"mount": "ophys_mount"
 		},
 		{
-			"id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
-			"mount": "ophys_mount"
+			"id": "35d1284e-4dfa-4ac3-9ba8-5ea1ae2fdaeb",
+			"mount": "2p_roi_classifier"
 		},
 		{
 			"id": "fb4b5cef-4505-4145-b8bd-e41d6863d7a9",

--- a/.codeocean/datasets.json
+++ b/.codeocean/datasets.json
@@ -2,7 +2,7 @@
 	"version": 1,
 	"attached_datasets": [
 		{
-			"id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"mount": "ophys_mount"
 		},
 		{

--- a/.codeocean/nextflow.json
+++ b/.codeocean/nextflow.json
@@ -89,10 +89,10 @@
 		{
 			"name": "capsule_aind_ophys_decrosstalk_roi_images_3",
 			"capsule": {
-				"id": "e31d29f8-7eee-446b-8f0a-2f027fe6f39b",
+				"id": "1383b25a-ecd2-4c56-8b7f-cde811c0b053",
 				"name": "aind-ophys-decrosstalk-roi-images",
-				"slug": "4612268",
-				"commit": "12d68566cceca25d6155b2989a430aee0cea9539"
+				"slug": "1533578",
+				"version": 9
 			},
 			"resources": {
 				"cpus": 16,

--- a/.codeocean/nextflow.json
+++ b/.codeocean/nextflow.json
@@ -4,10 +4,11 @@
 		{
 			"name": "capsule_aind_ophys_motion_correction_1",
 			"capsule": {
-				"id": "91a8ed4d-3b9a-49c6-9283-3f16ea5482bf",
+				"id": "63a8ce2e-f232-4590-9098-36b820202911",
 				"name": "aind-ophys-motion-correction",
-				"slug": "7474660",
-				"version": 14,
+				"slug": "5379831",
+				"commit": "d7786f962b59b541b73d1a813f32d90ad3e4b526",
+				"image_tag": "0da186b632b36a65afc14b406afd4686",
 				"app_panel": true
 			},
 			"resources": {
@@ -17,7 +18,7 @@
 			"inputs": [
 				{
 					"id": "shss8a841zxh45G9FnAZJ",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*json",
@@ -25,15 +26,15 @@
 				},
 				{
 					"id": "0lQ8_66t7slDYYl1N-Ivx",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
-					"source_path": "ophys_mount/*ophys/*platform*",
+					"source_path": "ophys_mount/pophys",
 					"collect": true
 				},
 				{
 					"id": "dW2sgE4QaeP-dBHA85AgR",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*/*.h5",
@@ -75,7 +76,7 @@
 				},
 				{
 					"id": "qjChmoJ20XeaEGPsHOjFC",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/session.json",
@@ -116,7 +117,7 @@
 				},
 				{
 					"id": "LArxCXhABUHL5Lbh",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -151,7 +152,7 @@
 			"inputs": [
 				{
 					"id": "Igz2SaWliTICjJ0j",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -184,7 +185,7 @@
 			"inputs": [
 				{
 					"id": "KODdbV6tmWHiSyI7",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -224,7 +225,7 @@
 			"inputs": [
 				{
 					"id": "SY9soR8Q8U93YM1v",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -244,10 +245,11 @@
 		{
 			"name": "capsule_aind_ophys_mesoscope_image_splitter_10",
 			"capsule": {
-				"id": "74cf5765-d490-4ff8-accc-8cca3cbd05ae",
+				"id": "c567666c-dd08-45dd-a824-6a570bd4675d",
 				"name": "aind-ophys-mesoscope-image-splitter",
-				"slug": "4287852",
-				"version": 3
+				"slug": "0115380",
+				"commit": "2874a49570d13c04790bf87f86ed4a61a4345166",
+				"image_tag": "43a670fd4eacc08b5a31923b9dcbd449"
 			},
 			"resources": {
 				"cpus": 16,
@@ -256,7 +258,7 @@
 			"inputs": [
 				{
 					"id": "1Yhj3z1s9qpaxr2Ge_QLI",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*",
@@ -337,7 +339,7 @@
 				},
 				{
 					"id": "6vEEC0shND9OPhAmaCKdT",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -408,7 +410,7 @@
 				},
 				{
 					"id": "0YzMlCgaBT94ZTbI",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/",
@@ -497,7 +499,7 @@
 			"inputs": [
 				{
 					"id": "CTLzZrixZbnhLROR",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/",
@@ -589,7 +591,7 @@
 				},
 				{
 					"id": "HKnQaTnuiUwFzKcA",
-					"source_id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/session.json",

--- a/.codeocean/nextflow.json
+++ b/.codeocean/nextflow.json
@@ -291,8 +291,8 @@
 				"app_panel": true
 			},
 			"resources": {
-				"cpus": 4,
-				"memory": 32
+				"cpus": 2,
+				"memory": 16
 			},
 			"inputs": [
 				{

--- a/.codeocean/nextflow.json
+++ b/.codeocean/nextflow.json
@@ -4,13 +4,10 @@
 		{
 			"name": "capsule_aind_ophys_motion_correction_1",
 			"capsule": {
-				"id": "63a8ce2e-f232-4590-9098-36b820202911",
+				"id": "91a8ed4d-3b9a-49c6-9283-3f16ea5482bf",
 				"name": "aind-ophys-motion-correction",
-				"slug": "5379831",
-				"commit": "1f56f03b4b077f37457fb35d76857b2c8ac65fa2",
-				"arguments": [
-					"--debug"
-				],
+				"slug": "7474660",
+				"version": 15,
 				"app_panel": true
 			},
 			"resources": {
@@ -20,7 +17,7 @@
 			"inputs": [
 				{
 					"id": "shss8a841zxh45G9FnAZJ",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*json",
@@ -28,7 +25,7 @@
 				},
 				{
 					"id": "0lQ8_66t7slDYYl1N-Ivx",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/pophys",
@@ -36,7 +33,7 @@
 				},
 				{
 					"id": "dW2sgE4QaeP-dBHA85AgR",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*/*.h5",
@@ -78,7 +75,7 @@
 				},
 				{
 					"id": "qjChmoJ20XeaEGPsHOjFC",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/session.json",
@@ -95,10 +92,7 @@
 				"id": "e31d29f8-7eee-446b-8f0a-2f027fe6f39b",
 				"name": "aind-ophys-decrosstalk-roi-images",
 				"slug": "4612268",
-				"commit": "12d68566cceca25d6155b2989a430aee0cea9539",
-				"arguments": [
-					"--debug"
-				]
+				"commit": "12d68566cceca25d6155b2989a430aee0cea9539"
 			},
 			"resources": {
 				"cpus": 16,
@@ -107,7 +101,7 @@
 			"inputs": [
 				{
 					"id": "LArxCXhABUHL5Lbh",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -115,7 +109,7 @@
 				},
 				{
 					"id": "zqpLi2VI7tiofBbS",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/pophys",
@@ -165,7 +159,7 @@
 			"inputs": [
 				{
 					"id": "Igz2SaWliTICjJ0j",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -198,7 +192,7 @@
 			"inputs": [
 				{
 					"id": "KODdbV6tmWHiSyI7",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -238,7 +232,7 @@
 			"inputs": [
 				{
 					"id": "SY9soR8Q8U93YM1v",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -258,10 +252,10 @@
 		{
 			"name": "capsule_aind_ophys_mesoscope_image_splitter_10",
 			"capsule": {
-				"id": "c567666c-dd08-45dd-a824-6a570bd4675d",
+				"id": "74cf5765-d490-4ff8-accc-8cca3cbd05ae",
 				"name": "aind-ophys-mesoscope-image-splitter",
-				"slug": "0115380",
-				"commit": "2874a49570d13c04790bf87f86ed4a61a4345166"
+				"slug": "4287852",
+				"version": 5
 			},
 			"resources": {
 				"cpus": 16,
@@ -270,7 +264,7 @@
 			"inputs": [
 				{
 					"id": "1Yhj3z1s9qpaxr2Ge_QLI",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*",
@@ -351,7 +345,7 @@
 				},
 				{
 					"id": "6vEEC0shND9OPhAmaCKdT",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
@@ -422,7 +416,7 @@
 				},
 				{
 					"id": "0YzMlCgaBT94ZTbI",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/",
@@ -511,7 +505,7 @@
 			"inputs": [
 				{
 					"id": "CTLzZrixZbnhLROR",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/",
@@ -603,7 +597,7 @@
 				},
 				{
 					"id": "HKnQaTnuiUwFzKcA",
-					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"source_id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/session.json",

--- a/.codeocean/nextflow.json
+++ b/.codeocean/nextflow.json
@@ -7,8 +7,10 @@
 				"id": "63a8ce2e-f232-4590-9098-36b820202911",
 				"name": "aind-ophys-motion-correction",
 				"slug": "5379831",
-				"commit": "d7786f962b59b541b73d1a813f32d90ad3e4b526",
-				"image_tag": "0da186b632b36a65afc14b406afd4686",
+				"commit": "1f56f03b4b077f37457fb35d76857b2c8ac65fa2",
+				"arguments": [
+					"--debug"
+				],
 				"app_panel": true
 			},
 			"resources": {
@@ -90,10 +92,13 @@
 		{
 			"name": "capsule_aind_ophys_decrosstalk_roi_images_3",
 			"capsule": {
-				"id": "1383b25a-ecd2-4c56-8b7f-cde811c0b053",
+				"id": "e31d29f8-7eee-446b-8f0a-2f027fe6f39b",
 				"name": "aind-ophys-decrosstalk-roi-images",
-				"slug": "1533578",
-				"version": 8
+				"slug": "4612268",
+				"commit": "12d68566cceca25d6155b2989a430aee0cea9539",
+				"arguments": [
+					"--debug"
+				]
 			},
 			"resources": {
 				"cpus": 16,
@@ -101,27 +106,35 @@
 			},
 			"inputs": [
 				{
-					"id": "41DF5BdXDa7xt6iEAutyw",
-					"source_id": "capsule_aind_ophys_decrosstalk_split_session_json_2",
-					"type": "capsule",
-					"name": "aind-ophys-decrosstalk-split-session-json",
-					"flatten": true
-				},
-				{
-					"id": "kCRtPyFKfilDA6Ts",
-					"source_id": "capsule_aind_ophys_mesoscope_image_splitter_10",
-					"type": "capsule",
-					"name": "aind-ophys-mesoscope-image-splitter",
-					"source_path": "*/V*_[0-9].h5",
-					"collect": true
-				},
-				{
 					"id": "LArxCXhABUHL5Lbh",
 					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 					"type": "dataset",
 					"name": "ophys_mount",
 					"source_path": "ophys_mount/*.json",
 					"collect": true
+				},
+				{
+					"id": "zqpLi2VI7tiofBbS",
+					"source_id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+					"type": "dataset",
+					"name": "ophys_mount",
+					"source_path": "ophys_mount/pophys",
+					"collect": true
+				},
+				{
+					"id": "kCRtPyFKfilDA6Ts",
+					"source_id": "capsule_aind_ophys_mesoscope_image_splitter_10",
+					"type": "capsule",
+					"name": "aind-ophys-mesoscope-image-splitter",
+					"source_path": "*/*",
+					"collect": true
+				},
+				{
+					"id": "41DF5BdXDa7xt6iEAutyw",
+					"source_id": "capsule_aind_ophys_decrosstalk_split_session_json_2",
+					"type": "capsule",
+					"name": "aind-ophys-decrosstalk-split-session-json",
+					"flatten": true
 				},
 				{
 					"id": "_xWzqVThoTLrrFDjgqJ4f",
@@ -248,8 +261,7 @@
 				"id": "c567666c-dd08-45dd-a824-6a570bd4675d",
 				"name": "aind-ophys-mesoscope-image-splitter",
 				"slug": "0115380",
-				"commit": "2874a49570d13c04790bf87f86ed4a61a4345166",
-				"image_tag": "43a670fd4eacc08b5a31923b9dcbd449"
+				"commit": "2874a49570d13c04790bf87f86ed4a61a4345166"
 			},
 			"resources": {
 				"cpus": 16,

--- a/.codeocean/pipeline-layout.json
+++ b/.codeocean/pipeline-layout.json
@@ -111,30 +111,29 @@
 			"target": "results"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_mesoscope_image_splitter_10",
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_mesoscope_image_splitter_10",
+			"selected": false,
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_mesoscope_image_splitter_10"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_motion_correction_1",
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_motion_correction_1",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_motion_correction_1"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_decrosstalk_split_session_json_2",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_decrosstalk_split_session_json_2",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_decrosstalk_split_session_json_2"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_pipeline_processing_metadata_aggregator_11",
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_pipeline_processing_metadata_aggregator_11",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_pipeline_processing_metadata_aggregator_11"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_extraction_suite_2_p_4",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_extraction_suite_2_p_4",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_extraction_suite_2_p_4"
 		},
 		{
@@ -143,15 +142,13 @@
 			"target": "capsule_aind_ophys_oasis_event_detection_9"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_nwb_12",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_nwb_12",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_nwb_12"
 		},
 		{
-			"id": "reactflow__edge-55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_nwb_packaging_subject_capsule_13",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_nwb_packaging_subject_capsule_13",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_nwb_packaging_subject_capsule_13"
 		},
 		{
@@ -243,9 +240,8 @@
 			"target": "results"
 		},
 		{
-			"id": "xy-edge__55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_decrosstalk_roi_images_3",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_decrosstalk_roi_images_3",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_decrosstalk_roi_images_3"
 		},
 		{
@@ -255,15 +251,13 @@
 			"target": "capsule_aind_ophys_decrosstalk_roi_images_3"
 		},
 		{
-			"id": "xy-edge__55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_dff_5",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_dff_5",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_dff_5"
 		},
 		{
-			"id": "xy-edge__55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_oasis_event_detection_9",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_oasis_event_detection_9",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_oasis_event_detection_9"
 		},
 		{
@@ -283,9 +277,8 @@
 			"target": "capsule_aind_ophys_classifier_17"
 		},
 		{
-			"id": "xy-edge__55f83fc7-9cc6-4b3c-8721-cc1f66590eab-capsule_aind_ophys_classifier_17",
-			"selected": false,
-			"source": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
+			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_classifier_17",
+			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_classifier_17"
 		},
 		{
@@ -341,14 +334,14 @@
 		},
 		{
 			"data": {
-				"capsule_id": "74cf5765-d490-4ff8-accc-8cca3cbd05ae"
+				"capsule_id": "c567666c-dd08-45dd-a824-6a570bd4675d"
 			},
 			"id": "capsule_aind_ophys_mesoscope_image_splitter_10",
 			"position": {
-				"x": 438.58834712494183,
-				"y": -1159.5083194894728
+				"x": 368.66630388698115,
+				"y": -1246.5541284183628
 			},
-			"selected": true,
+			"selected": false,
 			"type": "capsule"
 		},
 		{
@@ -421,15 +414,6 @@
 			"type": "dataset"
 		},
 		{
-			"id": "55f83fc7-9cc6-4b3c-8721-cc1f66590eab",
-			"position": {
-				"x": 220.06422842942686,
-				"y": -1528.761341822782
-			},
-			"selected": false,
-			"type": "dataset"
-		},
-		{
 			"data": {
 				"capsule_id": "d51df783-d892-4304-a129-238a9baea72a"
 			},
@@ -467,14 +451,14 @@
 		},
 		{
 			"data": {
-				"capsule_id": "91a8ed4d-3b9a-49c6-9283-3f16ea5482bf"
+				"capsule_id": "63a8ce2e-f232-4590-9098-36b820202911"
 			},
 			"id": "capsule_aind_ophys_motion_correction_1",
 			"position": {
-				"x": 817.6811160254667,
-				"y": -1032.7611267251477
+				"x": 648.2607185329339,
+				"y": -1047.9339928358222
 			},
-			"selected": false,
+			"selected": true,
 			"type": "capsule"
 		},
 		{
@@ -497,12 +481,20 @@
 			},
 			"selected": false,
 			"type": "capsule"
+		},
+		{
+			"id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"position": {
+				"x": 220.06422842942686,
+				"y": -1528.761341822782
+			},
+			"type": "dataset"
 		}
 	],
-	"timestamp": 1739212522902,
+	"timestamp": 1739392755085,
 	"viewport": {
-		"x": -307.3444447196699,
-		"y": 2071.4163243200865,
-		"zoom": 1.4211259342243583
+		"x": 430.6993322264391,
+		"y": 631.0753313794291,
+		"zoom": 0.3
 	}
 }

--- a/.codeocean/pipeline-layout.json
+++ b/.codeocean/pipeline-layout.json
@@ -111,31 +111,28 @@
 			"target": "results"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_mesoscope_image_splitter_10",
-			"selected": false,
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_mesoscope_image_splitter_10",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_mesoscope_image_splitter_10"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_motion_correction_1",
-			"selected": false,
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_motion_correction_1",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_motion_correction_1"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_decrosstalk_split_session_json_2",
-			"selected": false,
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_decrosstalk_split_session_json_2",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_decrosstalk_split_session_json_2"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_pipeline_processing_metadata_aggregator_11",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_pipeline_processing_metadata_aggregator_11",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_pipeline_processing_metadata_aggregator_11"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_extraction_suite_2_p_4",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_extraction_suite_2_p_4",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_extraction_suite_2_p_4"
 		},
 		{
@@ -144,13 +141,13 @@
 			"target": "capsule_aind_ophys_oasis_event_detection_9"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_nwb_12",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_nwb_12",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_nwb_12"
 		},
 		{
-			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_nwb_packaging_subject_capsule_13",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "reactflow__edge-1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_nwb_packaging_subject_capsule_13",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_nwb_packaging_subject_capsule_13"
 		},
 		{
@@ -242,9 +239,8 @@
 			"target": "results"
 		},
 		{
-			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_decrosstalk_roi_images_3",
-			"selected": false,
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "xy-edge__1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_decrosstalk_roi_images_3",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_decrosstalk_roi_images_3"
 		},
 		{
@@ -254,13 +250,13 @@
 			"target": "capsule_aind_ophys_decrosstalk_roi_images_3"
 		},
 		{
-			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_dff_5",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "xy-edge__1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_dff_5",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_dff_5"
 		},
 		{
-			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_oasis_event_detection_9",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "xy-edge__1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_oasis_event_detection_9",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_oasis_event_detection_9"
 		},
 		{
@@ -280,8 +276,8 @@
 			"target": "capsule_aind_ophys_classifier_17"
 		},
 		{
-			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_classifier_17",
-			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "xy-edge__1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_classifier_17",
+			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_classifier_17"
 		},
 		{
@@ -337,14 +333,14 @@
 		},
 		{
 			"data": {
-				"capsule_id": "c567666c-dd08-45dd-a824-6a570bd4675d"
+				"capsule_id": "74cf5765-d490-4ff8-accc-8cca3cbd05ae"
 			},
 			"id": "capsule_aind_ophys_mesoscope_image_splitter_10",
 			"position": {
 				"x": 515.3329705536478,
 				"y": -1316.554128418363
 			},
-			"selected": false,
+			"selected": true,
 			"type": "capsule"
 		},
 		{
@@ -377,8 +373,8 @@
 			},
 			"id": "capsule_aind_ophys_extraction_suite_2_p_4",
 			"position": {
-				"x": -615.0250753917447,
-				"y": -521.2096795215662
+				"x": -647.7395271781199,
+				"y": -1350.793619458871
 			},
 			"selected": false,
 			"type": "capsule"
@@ -454,7 +450,7 @@
 		},
 		{
 			"data": {
-				"capsule_id": "63a8ce2e-f232-4590-9098-36b820202911"
+				"capsule_id": "91a8ed4d-3b9a-49c6-9283-3f16ea5482bf"
 			},
 			"id": "capsule_aind_ophys_motion_correction_1",
 			"position": {
@@ -486,19 +482,18 @@
 			"type": "capsule"
 		},
 		{
-			"id": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
+			"id": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"position": {
 				"x": 220.06422842942686,
 				"y": -1528.761341822782
 			},
-			"selected": false,
 			"type": "dataset"
 		}
 	],
-	"timestamp": 1739399711658,
+	"timestamp": 1739552826879,
 	"viewport": {
-		"x": -115.76600434721968,
-		"y": 880.8110453778346,
-		"zoom": 0.8072203251130955
+		"x": 54.03490757441179,
+		"y": 570.681531546657,
+		"zoom": 0.33496466660543794
 	}
 }

--- a/.codeocean/pipeline-layout.json
+++ b/.codeocean/pipeline-layout.json
@@ -240,6 +240,7 @@
 		},
 		{
 			"id": "xy-edge__1d41a92d-2f10-40d1-830d-83ba23aca8bd-capsule_aind_ophys_decrosstalk_roi_images_3",
+			"selected": false,
 			"source": "1d41a92d-2f10-40d1-830d-83ba23aca8bd",
 			"target": "capsule_aind_ophys_decrosstalk_roi_images_3"
 		},
@@ -309,14 +310,14 @@
 		},
 		{
 			"data": {
-				"capsule_id": "e31d29f8-7eee-446b-8f0a-2f027fe6f39b"
+				"capsule_id": "1383b25a-ecd2-4c56-8b7f-cde811c0b053"
 			},
 			"id": "capsule_aind_ophys_decrosstalk_roi_images_3",
 			"position": {
 				"x": -40.5450808311457,
 				"y": -705.4004235465757
 			},
-			"selected": false,
+			"selected": true,
 			"type": "capsule"
 		},
 		{
@@ -340,7 +341,7 @@
 				"x": 515.3329705536478,
 				"y": -1316.554128418363
 			},
-			"selected": true,
+			"selected": false,
 			"type": "capsule"
 		},
 		{
@@ -490,10 +491,10 @@
 			"type": "dataset"
 		}
 	],
-	"timestamp": 1739552826879,
+	"timestamp": 1739553159499,
 	"viewport": {
-		"x": 54.03490757441179,
-		"y": 570.681531546657,
+		"x": 201.0349075744118,
+		"y": 551.681531546657,
 		"zoom": 0.33496466660543794
 	}
 }

--- a/.codeocean/pipeline-layout.json
+++ b/.codeocean/pipeline-layout.json
@@ -118,11 +118,13 @@
 		},
 		{
 			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_motion_correction_1",
+			"selected": false,
 			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_motion_correction_1"
 		},
 		{
 			"id": "reactflow__edge-1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_decrosstalk_split_session_json_2",
+			"selected": false,
 			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_decrosstalk_split_session_json_2"
 		},
@@ -241,6 +243,7 @@
 		},
 		{
 			"id": "xy-edge__1bfb83fd-7b92-4a1d-827b-9d0acc17eedd-capsule_aind_ophys_decrosstalk_roi_images_3",
+			"selected": false,
 			"source": "1bfb83fd-7b92-4a1d-827b-9d0acc17eedd",
 			"target": "capsule_aind_ophys_decrosstalk_roi_images_3"
 		},
@@ -310,12 +313,12 @@
 		},
 		{
 			"data": {
-				"capsule_id": "1383b25a-ecd2-4c56-8b7f-cde811c0b053"
+				"capsule_id": "e31d29f8-7eee-446b-8f0a-2f027fe6f39b"
 			},
 			"id": "capsule_aind_ophys_decrosstalk_roi_images_3",
 			"position": {
-				"x": -103.02669039441344,
-				"y": -735.6945372742207
+				"x": -40.5450808311457,
+				"y": -705.4004235465757
 			},
 			"selected": false,
 			"type": "capsule"
@@ -338,8 +341,8 @@
 			},
 			"id": "capsule_aind_ophys_mesoscope_image_splitter_10",
 			"position": {
-				"x": 368.66630388698115,
-				"y": -1246.5541284183628
+				"x": 515.3329705536478,
+				"y": -1316.554128418363
 			},
 			"selected": false,
 			"type": "capsule"
@@ -350,8 +353,8 @@
 			},
 			"id": "capsule_aind_ophys_decrosstalk_split_session_json_2",
 			"position": {
-				"x": 483.3932101563523,
-				"y": -774.544236979064
+				"x": 574.0161264801575,
+				"y": -901.8662830636109
 			},
 			"selected": false,
 			"type": "capsule"
@@ -443,8 +446,8 @@
 			},
 			"id": "capsule_aind_ophys_quality_control_aggregator_16",
 			"position": {
-				"x": 1161.7889368055303,
-				"y": 294.9580277491974
+				"x": 1086.5605757349385,
+				"y": -88.28441085980361
 			},
 			"selected": false,
 			"type": "capsule"
@@ -455,10 +458,10 @@
 			},
 			"id": "capsule_aind_ophys_motion_correction_1",
 			"position": {
-				"x": 648.2607185329339,
-				"y": -1047.9339928358222
+				"x": 888.7202462461157,
+				"y": -1250.5258783894478
 			},
-			"selected": true,
+			"selected": false,
 			"type": "capsule"
 		},
 		{
@@ -488,13 +491,14 @@
 				"x": 220.06422842942686,
 				"y": -1528.761341822782
 			},
+			"selected": false,
 			"type": "dataset"
 		}
 	],
-	"timestamp": 1739392755085,
+	"timestamp": 1739399711658,
 	"viewport": {
-		"x": 430.6993322264391,
-		"y": 631.0753313794291,
-		"zoom": 0.3
+		"x": -115.76600434721968,
+		"y": 880.8110453778346,
+		"zoom": 0.8072203251130955
 	}
 }

--- a/.codeocean/settings.json
+++ b/.codeocean/settings.json
@@ -4,5 +4,10 @@
 	"role": {
 		"role_arn": "arn:aws:iam::467914378000:role/aind-codeocean-user"
 	},
+	"nextflow_error_strategy": {
+		"error_strategy": "retry",
+		"max_retries": 1,
+		"max_errors": 1
+	},
 	"verbose_logs": true
 }

--- a/.codeocean/settings.json
+++ b/.codeocean/settings.json
@@ -4,10 +4,5 @@
 	"role": {
 		"role_arn": "arn:aws:iam::467914378000:role/aind-codeocean-user"
 	},
-	"nextflow_error_strategy": {
-		"error_strategy": "retry",
-		"max_retries": 1,
-		"max_errors": 1
-	},
 	"verbose_logs": true
 }

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -1,5 +1,5 @@
 #!/usr/bin/env nextflow
-// hash:sha256:4000254e8e48740a5961f49078adfc0a39ede3f09f55d0435a93297648a1c8cd
+// hash:sha256:af47b618aedc2320c5dfb3ee251ea3df07631603fffa0e72bc5c51606030e467
 
 nextflow.enable.dsl = 1
 
@@ -155,8 +155,8 @@ process capsule_aind_ophys_decrosstalk_split_session_json_2 {
 
 // capsule - aind-ophys-decrosstalk-roi-images
 process capsule_aind_ophys_decrosstalk_roi_images_3 {
-	tag 'capsule-4612268'
-	container "$REGISTRY_HOST/capsule/e31d29f8-7eee-446b-8f0a-2f027fe6f39b"
+	tag 'capsule-1533578'
+	container "$REGISTRY_HOST/published/1383b25a-ecd2-4c56-8b7f-cde811c0b053:v9"
 
 	cpus 16
 	memory '128 GB'
@@ -181,7 +181,7 @@ process capsule_aind_ophys_decrosstalk_roi_images_3 {
 	#!/usr/bin/env bash
 	set -e
 
-	export CO_CAPSULE_ID=e31d29f8-7eee-446b-8f0a-2f027fe6f39b
+	export CO_CAPSULE_ID=1383b25a-ecd2-4c56-8b7f-cde811c0b053
 	export CO_CPUS=16
 	export CO_MEMORY=137438953472
 
@@ -191,8 +191,7 @@ process capsule_aind_ophys_decrosstalk_roi_images_3 {
 	mkdir -p capsule/scratch && ln -s \$PWD/capsule/scratch /scratch
 
 	echo "[${task.tag}] cloning git repo..."
-	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4612268.git" capsule-repo
-	git -C capsule-repo checkout 12d68566cceca25d6155b2989a430aee0cea9539 --quiet
+	git clone --branch v9.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-1533578.git" capsule-repo
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -1,12 +1,12 @@
 #!/usr/bin/env nextflow
-// hash:sha256:2d993cea68670b11882c764937ddb059bcba089acc6b116e78377e4ca8a69ad7
+// hash:sha256:3fd6cbd6e830ef46203c2b368deb07425cdb73b944a84ba36f9dbd8050810be6
 
 nextflow.enable.dsl = 1
 
-params.ophys_mount_url = 's3://aind-private-data-prod-o5171v/multiplane-ophys_749013_2024-11-13_14-42-09'
+params.ophys_mount_url = 's3://aind-private-data-prod-o5171v/multiplane-ophys_746540_2024-09-30_14-52-23'
 
 ophys_mount_to_aind_ophys_motion_correction_1 = channel.fromPath(params.ophys_mount_url + "/*json", type: 'any')
-ophys_mount_to_aind_ophys_motion_correction_2 = channel.fromPath(params.ophys_mount_url + "/*ophys/*platform*", type: 'any')
+ophys_mount_to_aind_ophys_motion_correction_2 = channel.fromPath(params.ophys_mount_url + "/pophys", type: 'any')
 ophys_mount_to_aind_ophys_motion_correction_3 = channel.fromPath(params.ophys_mount_url + "/*/*.h5", type: 'any')
 capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_motion_correction_1_4 = channel.create()
 capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_split_session_json_2_5 = channel.create()
@@ -51,8 +51,8 @@ ophys_mount_to_aind_ophys_classifier_43 = channel.fromPath(params.ophys_mount_ur
 
 // capsule - aind-ophys-motion-correction
 process capsule_aind_ophys_motion_correction_1 {
-	tag 'capsule-7474660'
-	container "$REGISTRY_HOST/published/91a8ed4d-3b9a-49c6-9283-3f16ea5482bf:v14"
+	tag 'capsule-5379831'
+	container "$REGISTRY_HOST/capsule/63a8ce2e-f232-4590-9098-36b820202911:0da186b632b36a65afc14b406afd4686"
 
 	cpus 16
 	memory '128 GB'
@@ -83,7 +83,7 @@ process capsule_aind_ophys_motion_correction_1 {
 	#!/usr/bin/env bash
 	set -e
 
-	export CO_CAPSULE_ID=91a8ed4d-3b9a-49c6-9283-3f16ea5482bf
+	export CO_CAPSULE_ID=63a8ce2e-f232-4590-9098-36b820202911
 	export CO_CPUS=16
 	export CO_MEMORY=137438953472
 
@@ -93,7 +93,8 @@ process capsule_aind_ophys_motion_correction_1 {
 	mkdir -p capsule/scratch && ln -s \$PWD/capsule/scratch /scratch
 
 	echo "[${task.tag}] cloning git repo..."
-	git clone --branch v14.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-7474660.git" capsule-repo
+	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-5379831.git" capsule-repo
+	git -C capsule-repo checkout d7786f962b59b541b73d1a813f32d90ad3e4b526 --quiet
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 
@@ -350,8 +351,8 @@ process capsule_aind_ophys_oasis_event_detection_9 {
 
 // capsule - aind-ophys-mesoscope-image-splitter
 process capsule_aind_ophys_mesoscope_image_splitter_10 {
-	tag 'capsule-4287852'
-	container "$REGISTRY_HOST/published/74cf5765-d490-4ff8-accc-8cca3cbd05ae:v3"
+	tag 'capsule-0115380'
+	container "$REGISTRY_HOST/capsule/c567666c-dd08-45dd-a824-6a570bd4675d:43a670fd4eacc08b5a31923b9dcbd449"
 
 	cpus 16
 	memory '128 GB'
@@ -368,7 +369,7 @@ process capsule_aind_ophys_mesoscope_image_splitter_10 {
 	#!/usr/bin/env bash
 	set -e
 
-	export CO_CAPSULE_ID=74cf5765-d490-4ff8-accc-8cca3cbd05ae
+	export CO_CAPSULE_ID=c567666c-dd08-45dd-a824-6a570bd4675d
 	export CO_CPUS=16
 	export CO_MEMORY=137438953472
 
@@ -378,7 +379,8 @@ process capsule_aind_ophys_mesoscope_image_splitter_10 {
 	mkdir -p capsule/scratch && ln -s \$PWD/capsule/scratch /scratch
 
 	echo "[${task.tag}] cloning git repo..."
-	git clone --branch v3.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4287852.git" capsule-repo
+	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-0115380.git" capsule-repo
+	git -C capsule-repo checkout 2874a49570d13c04790bf87f86ed4a61a4345166 --quiet
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
-// hash:sha256:9887c274335902977633ed0233f2d051c34bffa3609b8c4e9d70c5099fda0419
+// hash:sha256:4000254e8e48740a5961f49078adfc0a39ede3f09f55d0435a93297648a1c8cd
 
 nextflow.enable.dsl = 1
 
-params.ophys_mount_url = 's3://aind-private-data-prod-o5171v/multiplane-ophys_746540_2024-09-30_14-52-23'
+params.ophys_mount_url = 's3://aind-private-data-prod-o5171v/multiplane-ophys_767018_2025-02-10_13-04-43'
 
 ophys_mount_to_aind_ophys_motion_correction_1 = channel.fromPath(params.ophys_mount_url + "/*json", type: 'any')
 ophys_mount_to_aind_ophys_motion_correction_2 = channel.fromPath(params.ophys_mount_url + "/pophys", type: 'any')
@@ -52,8 +52,8 @@ ophys_mount_to_aind_ophys_classifier_44 = channel.fromPath(params.ophys_mount_ur
 
 // capsule - aind-ophys-motion-correction
 process capsule_aind_ophys_motion_correction_1 {
-	tag 'capsule-5379831'
-	container "$REGISTRY_HOST/capsule/63a8ce2e-f232-4590-9098-36b820202911"
+	tag 'capsule-7474660'
+	container "$REGISTRY_HOST/published/91a8ed4d-3b9a-49c6-9283-3f16ea5482bf:v15"
 
 	cpus 16
 	memory '128 GB'
@@ -84,7 +84,7 @@ process capsule_aind_ophys_motion_correction_1 {
 	#!/usr/bin/env bash
 	set -e
 
-	export CO_CAPSULE_ID=63a8ce2e-f232-4590-9098-36b820202911
+	export CO_CAPSULE_ID=91a8ed4d-3b9a-49c6-9283-3f16ea5482bf
 	export CO_CPUS=16
 	export CO_MEMORY=137438953472
 
@@ -94,15 +94,14 @@ process capsule_aind_ophys_motion_correction_1 {
 	mkdir -p capsule/scratch && ln -s \$PWD/capsule/scratch /scratch
 
 	echo "[${task.tag}] cloning git repo..."
-	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-5379831.git" capsule-repo
-	git -C capsule-repo checkout 1f56f03b4b077f37457fb35d76857b2c8ac65fa2 --quiet
+	git clone --branch v15.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-7474660.git" capsule-repo
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 
 	echo "[${task.tag}] running capsule..."
 	cd capsule/code
 	chmod +x run
-	./run --debug
+	./run ${params.capsule_aind_ophys_motion_correction_1_args}
 
 	echo "[${task.tag}] completed!"
 	"""
@@ -200,7 +199,7 @@ process capsule_aind_ophys_decrosstalk_roi_images_3 {
 	echo "[${task.tag}] running capsule..."
 	cd capsule/code
 	chmod +x run
-	./run --debug
+	./run
 
 	echo "[${task.tag}] completed!"
 	"""
@@ -354,8 +353,8 @@ process capsule_aind_ophys_oasis_event_detection_9 {
 
 // capsule - aind-ophys-mesoscope-image-splitter
 process capsule_aind_ophys_mesoscope_image_splitter_10 {
-	tag 'capsule-0115380'
-	container "$REGISTRY_HOST/capsule/c567666c-dd08-45dd-a824-6a570bd4675d"
+	tag 'capsule-4287852'
+	container "$REGISTRY_HOST/published/74cf5765-d490-4ff8-accc-8cca3cbd05ae:v5"
 
 	cpus 16
 	memory '128 GB'
@@ -372,7 +371,7 @@ process capsule_aind_ophys_mesoscope_image_splitter_10 {
 	#!/usr/bin/env bash
 	set -e
 
-	export CO_CAPSULE_ID=c567666c-dd08-45dd-a824-6a570bd4675d
+	export CO_CAPSULE_ID=74cf5765-d490-4ff8-accc-8cca3cbd05ae
 	export CO_CPUS=16
 	export CO_MEMORY=137438953472
 
@@ -382,8 +381,7 @@ process capsule_aind_ophys_mesoscope_image_splitter_10 {
 	mkdir -p capsule/scratch && ln -s \$PWD/capsule/scratch /scratch
 
 	echo "[${task.tag}] cloning git repo..."
-	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-0115380.git" capsule-repo
-	git -C capsule-repo checkout 2874a49570d13c04790bf87f86ed4a61a4345166 --quiet
+	git clone --branch v5.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4287852.git" capsule-repo
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -1,5 +1,5 @@
 #!/usr/bin/env nextflow
-// hash:sha256:3fd6cbd6e830ef46203c2b368deb07425cdb73b944a84ba36f9dbd8050810be6
+// hash:sha256:9887c274335902977633ed0233f2d051c34bffa3609b8c4e9d70c5099fda0419
 
 nextflow.enable.dsl = 1
 
@@ -11,48 +11,49 @@ ophys_mount_to_aind_ophys_motion_correction_3 = channel.fromPath(params.ophys_mo
 capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_motion_correction_1_4 = channel.create()
 capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_split_session_json_2_5 = channel.create()
 ophys_mount_to_aind_ophys_decrosstalk_split_session_json_6 = channel.fromPath(params.ophys_mount_url + "/session.json", type: 'any')
-capsule_aind_ophys_decrosstalk_split_session_json_2_to_capsule_aind_ophys_decrosstalk_roi_images_3_7 = channel.create()
-capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_decrosstalk_roi_images_3_8 = channel.create()
-ophys_mount_to_aind_ophys_decrosstalk_roi_images_9 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
-capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_roi_images_3_10 = channel.create()
-ophys_mount_to_aind_ophys_extraction_suite2p_11 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
-capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_extraction_suite_2_p_4_12 = channel.create()
-ophys_mount_to_aind_ophys_dff_13 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
-capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_dff_5_14 = channel.create()
-capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_dff_5_15 = channel.create()
-ophys_mount_to_aind_ophys_oasis_event_detection_16 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
-capsule_aind_ophys_dff_5_to_capsule_aind_ophys_oasis_event_detection_9_17 = channel.create()
-ophys_mount_to_aind_ophys_mesoscope_image_splitter_18 = channel.fromPath(params.ophys_mount_url + "/", type: 'any')
-capsule_aind_ophys_classifier_17_to_capsule_aind_pipeline_processing_metadata_aggregator_11_19 = channel.create()
-capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_pipeline_processing_metadata_aggregator_11_20 = channel.create()
-capsule_aind_ophys_dff_5_to_capsule_aind_pipeline_processing_metadata_aggregator_11_21 = channel.create()
-capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_pipeline_processing_metadata_aggregator_11_22 = channel.create()
-capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_pipeline_processing_metadata_aggregator_11_23 = channel.create()
-capsule_aind_ophys_motion_correction_1_to_capsule_aind_pipeline_processing_metadata_aggregator_11_24 = channel.create()
-ophys_mount_to_aind_pipeline_processing_metadata_aggregator_25 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
-capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_nwb_12_26 = channel.create()
-capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_27 = channel.create()
+ophys_mount_to_aind_ophys_decrosstalk_roi_images_7 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
+ophys_mount_to_aind_ophys_decrosstalk_roi_images_8 = channel.fromPath(params.ophys_mount_url + "/pophys", type: 'any')
+capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_decrosstalk_roi_images_3_9 = channel.create()
+capsule_aind_ophys_decrosstalk_split_session_json_2_to_capsule_aind_ophys_decrosstalk_roi_images_3_10 = channel.create()
+capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_roi_images_3_11 = channel.create()
+ophys_mount_to_aind_ophys_extraction_suite2p_12 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
+capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_extraction_suite_2_p_4_13 = channel.create()
+ophys_mount_to_aind_ophys_dff_14 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
+capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_dff_5_15 = channel.create()
+capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_dff_5_16 = channel.create()
+ophys_mount_to_aind_ophys_oasis_event_detection_17 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
+capsule_aind_ophys_dff_5_to_capsule_aind_ophys_oasis_event_detection_9_18 = channel.create()
+ophys_mount_to_aind_ophys_mesoscope_image_splitter_19 = channel.fromPath(params.ophys_mount_url + "/", type: 'any')
+capsule_aind_ophys_classifier_17_to_capsule_aind_pipeline_processing_metadata_aggregator_11_20 = channel.create()
+capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_pipeline_processing_metadata_aggregator_11_21 = channel.create()
+capsule_aind_ophys_dff_5_to_capsule_aind_pipeline_processing_metadata_aggregator_11_22 = channel.create()
+capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_pipeline_processing_metadata_aggregator_11_23 = channel.create()
+capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_pipeline_processing_metadata_aggregator_11_24 = channel.create()
+capsule_aind_ophys_motion_correction_1_to_capsule_aind_pipeline_processing_metadata_aggregator_11_25 = channel.create()
+ophys_mount_to_aind_pipeline_processing_metadata_aggregator_26 = channel.fromPath(params.ophys_mount_url + "/*.json", type: 'any')
+capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_nwb_12_27 = channel.create()
 capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_28 = channel.create()
 capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_29 = channel.create()
 capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_30 = channel.create()
-ophys_mount_to_aind_ophys_nwb_31 = channel.fromPath(params.ophys_mount_url + "/", type: 'any')
-capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_ophys_nwb_12_32 = channel.create()
-capsule_aind_ophys_dff_5_to_capsule_aind_ophys_nwb_12_33 = channel.create()
-capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_34 = channel.create()
+capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_31 = channel.create()
+ophys_mount_to_aind_ophys_nwb_32 = channel.fromPath(params.ophys_mount_url + "/", type: 'any')
+capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_ophys_nwb_12_33 = channel.create()
+capsule_aind_ophys_dff_5_to_capsule_aind_ophys_nwb_12_34 = channel.create()
 capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_35 = channel.create()
-capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_nwb_12_36 = channel.create()
-capsule_nwb_packaging_subject_capsule_13_to_capsule_aind_ophys_nwb_12_37 = channel.create()
-ophys_mount_to_nwb_packaging_subject_capsule_38 = channel.fromPath(params.ophys_mount_url + "/", type: 'any')
-capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_movie_qc_15_39 = channel.create()
-capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_quality_control_aggregator_16_40 = channel.create()
-capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_quality_control_aggregator_16_41 = channel.create()
-capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_classifier_17_42 = channel.create()
-ophys_mount_to_aind_ophys_classifier_43 = channel.fromPath(params.ophys_mount_url + "/session.json", type: 'any')
+capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_36 = channel.create()
+capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_nwb_12_37 = channel.create()
+capsule_nwb_packaging_subject_capsule_13_to_capsule_aind_ophys_nwb_12_38 = channel.create()
+ophys_mount_to_nwb_packaging_subject_capsule_39 = channel.fromPath(params.ophys_mount_url + "/", type: 'any')
+capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_movie_qc_15_40 = channel.create()
+capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_quality_control_aggregator_16_41 = channel.create()
+capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_quality_control_aggregator_16_42 = channel.create()
+capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_classifier_17_43 = channel.create()
+ophys_mount_to_aind_ophys_classifier_44 = channel.fromPath(params.ophys_mount_url + "/session.json", type: 'any')
 
 // capsule - aind-ophys-motion-correction
 process capsule_aind_ophys_motion_correction_1 {
 	tag 'capsule-5379831'
-	container "$REGISTRY_HOST/capsule/63a8ce2e-f232-4590-9098-36b820202911:0da186b632b36a65afc14b406afd4686"
+	container "$REGISTRY_HOST/capsule/63a8ce2e-f232-4590-9098-36b820202911"
 
 	cpus 16
 	memory '128 GB'
@@ -68,15 +69,15 @@ process capsule_aind_ophys_motion_correction_1 {
 	output:
 	path 'capsule/results/*'
 	path 'capsule/results/V*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_split_session_json_2_5
-	path 'capsule/results/V*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_roi_images_3_10
-	path 'capsule/results/*/motion_correction/*transform.csv' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_dff_5_15
-	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_pipeline_processing_metadata_aggregator_11_24
-	path 'capsule/results/*/motion_correction/*.png' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_27
-	path 'capsule/results/*/motion_correction/*.h5' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_28
-	path 'capsule/results/*/motion_correction/*.webm' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_29
-	path 'capsule/results/*/motion_correction/*.csv' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_30
-	path 'capsule/results/V*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_movie_qc_15_39
-	path 'capsule/results/*/motion_correction/*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_quality_control_aggregator_16_41
+	path 'capsule/results/V*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_roi_images_3_11
+	path 'capsule/results/*/motion_correction/*transform.csv' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_dff_5_16
+	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_pipeline_processing_metadata_aggregator_11_25
+	path 'capsule/results/*/motion_correction/*.png' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_28
+	path 'capsule/results/*/motion_correction/*.h5' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_29
+	path 'capsule/results/*/motion_correction/*.webm' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_30
+	path 'capsule/results/*/motion_correction/*.csv' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_31
+	path 'capsule/results/V*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_movie_qc_15_40
+	path 'capsule/results/*/motion_correction/*' into capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_quality_control_aggregator_16_42
 
 	script:
 	"""
@@ -94,14 +95,14 @@ process capsule_aind_ophys_motion_correction_1 {
 
 	echo "[${task.tag}] cloning git repo..."
 	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-5379831.git" capsule-repo
-	git -C capsule-repo checkout d7786f962b59b541b73d1a813f32d90ad3e4b526 --quiet
+	git -C capsule-repo checkout 1f56f03b4b077f37457fb35d76857b2c8ac65fa2 --quiet
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 
 	echo "[${task.tag}] running capsule..."
 	cd capsule/code
 	chmod +x run
-	./run ${params.capsule_aind_ophys_motion_correction_1_args}
+	./run --debug
 
 	echo "[${task.tag}] completed!"
 	"""
@@ -123,7 +124,7 @@ process capsule_aind_ophys_decrosstalk_split_session_json_2 {
 
 	output:
 	path 'capsule/results/*'
-	path 'capsule/results/*' into capsule_aind_ophys_decrosstalk_split_session_json_2_to_capsule_aind_ophys_decrosstalk_roi_images_3_7
+	path 'capsule/results/*' into capsule_aind_ophys_decrosstalk_split_session_json_2_to_capsule_aind_ophys_decrosstalk_roi_images_3_10
 
 	script:
 	"""
@@ -155,8 +156,8 @@ process capsule_aind_ophys_decrosstalk_split_session_json_2 {
 
 // capsule - aind-ophys-decrosstalk-roi-images
 process capsule_aind_ophys_decrosstalk_roi_images_3 {
-	tag 'capsule-1533578'
-	container "$REGISTRY_HOST/published/1383b25a-ecd2-4c56-8b7f-cde811c0b053:v8"
+	tag 'capsule-4612268'
+	container "$REGISTRY_HOST/capsule/e31d29f8-7eee-446b-8f0a-2f027fe6f39b"
 
 	cpus 16
 	memory '128 GB'
@@ -164,23 +165,24 @@ process capsule_aind_ophys_decrosstalk_roi_images_3 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from capsule_aind_ophys_decrosstalk_split_session_json_2_to_capsule_aind_ophys_decrosstalk_roi_images_3_7.flatten()
-	path 'capsule/data/' from capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_decrosstalk_roi_images_3_8.collect()
-	path 'capsule/data/' from ophys_mount_to_aind_ophys_decrosstalk_roi_images_9.collect()
-	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_roi_images_3_10.collect()
+	path 'capsule/data/' from ophys_mount_to_aind_ophys_decrosstalk_roi_images_7.collect()
+	path 'capsule/data/' from ophys_mount_to_aind_ophys_decrosstalk_roi_images_8.collect()
+	path 'capsule/data/' from capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_decrosstalk_roi_images_3_9.collect()
+	path 'capsule/data/' from capsule_aind_ophys_decrosstalk_split_session_json_2_to_capsule_aind_ophys_decrosstalk_roi_images_3_10.flatten()
+	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_decrosstalk_roi_images_3_11.collect()
 
 	output:
 	path 'capsule/results/*'
-	path 'capsule/results/*' into capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_extraction_suite_2_p_4_12
-	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_pipeline_processing_metadata_aggregator_11_23
-	path 'capsule/results/*/decrosstalk/*.h5' into capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_nwb_12_36
+	path 'capsule/results/*' into capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_extraction_suite_2_p_4_13
+	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_pipeline_processing_metadata_aggregator_11_24
+	path 'capsule/results/*/decrosstalk/*.h5' into capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_nwb_12_37
 
 	script:
 	"""
 	#!/usr/bin/env bash
 	set -e
 
-	export CO_CAPSULE_ID=1383b25a-ecd2-4c56-8b7f-cde811c0b053
+	export CO_CAPSULE_ID=e31d29f8-7eee-446b-8f0a-2f027fe6f39b
 	export CO_CPUS=16
 	export CO_MEMORY=137438953472
 
@@ -190,14 +192,15 @@ process capsule_aind_ophys_decrosstalk_roi_images_3 {
 	mkdir -p capsule/scratch && ln -s \$PWD/capsule/scratch /scratch
 
 	echo "[${task.tag}] cloning git repo..."
-	git clone --branch v8.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-1533578.git" capsule-repo
+	git clone "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4612268.git" capsule-repo
+	git -C capsule-repo checkout 12d68566cceca25d6155b2989a430aee0cea9539 --quiet
 	mv capsule-repo/code capsule/code
 	rm -rf capsule-repo
 
 	echo "[${task.tag}] running capsule..."
 	cd capsule/code
 	chmod +x run
-	./run
+	./run --debug
 
 	echo "[${task.tag}] completed!"
 	"""
@@ -214,16 +217,16 @@ process capsule_aind_ophys_extraction_suite_2_p_4 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from ophys_mount_to_aind_ophys_extraction_suite2p_11.collect()
-	path 'capsule/data/' from capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_extraction_suite_2_p_4_12.flatten()
+	path 'capsule/data/' from ophys_mount_to_aind_ophys_extraction_suite2p_12.collect()
+	path 'capsule/data/' from capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_extraction_suite_2_p_4_13.flatten()
 
 	output:
 	path 'capsule/results/*'
-	path 'capsule/results/*' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_dff_5_14
-	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_pipeline_processing_metadata_aggregator_11_22
-	path 'capsule/results/*/extraction/*.h5' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_34
-	path 'capsule/results/*/extraction/*.png' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_35
-	path 'capsule/results/*' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_classifier_17_42
+	path 'capsule/results/*' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_dff_5_15
+	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_pipeline_processing_metadata_aggregator_11_23
+	path 'capsule/results/*/extraction/*.h5' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_35
+	path 'capsule/results/*/extraction/*.png' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_36
+	path 'capsule/results/*' into capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_classifier_17_43
 
 	script:
 	"""
@@ -264,15 +267,15 @@ process capsule_aind_ophys_dff_5 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from ophys_mount_to_aind_ophys_dff_13.collect()
-	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_dff_5_14
-	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_dff_5_15.collect()
+	path 'capsule/data/' from ophys_mount_to_aind_ophys_dff_14.collect()
+	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_dff_5_15
+	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_dff_5_16.collect()
 
 	output:
 	path 'capsule/results/*'
-	path 'capsule/results/*' into capsule_aind_ophys_dff_5_to_capsule_aind_ophys_oasis_event_detection_9_17
-	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_dff_5_to_capsule_aind_pipeline_processing_metadata_aggregator_11_21
-	path 'capsule/results/*/dff/*.h5' into capsule_aind_ophys_dff_5_to_capsule_aind_ophys_nwb_12_33
+	path 'capsule/results/*' into capsule_aind_ophys_dff_5_to_capsule_aind_ophys_oasis_event_detection_9_18
+	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_dff_5_to_capsule_aind_pipeline_processing_metadata_aggregator_11_22
+	path 'capsule/results/*/dff/*.h5' into capsule_aind_ophys_dff_5_to_capsule_aind_ophys_nwb_12_34
 
 	script:
 	"""
@@ -313,13 +316,13 @@ process capsule_aind_ophys_oasis_event_detection_9 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from ophys_mount_to_aind_ophys_oasis_event_detection_16.collect()
-	path 'capsule/data/' from capsule_aind_ophys_dff_5_to_capsule_aind_ophys_oasis_event_detection_9_17
+	path 'capsule/data/' from ophys_mount_to_aind_ophys_oasis_event_detection_17.collect()
+	path 'capsule/data/' from capsule_aind_ophys_dff_5_to_capsule_aind_ophys_oasis_event_detection_9_18
 
 	output:
 	path 'capsule/results/*'
-	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_pipeline_processing_metadata_aggregator_11_20
-	path 'capsule/results/*/events/*.h5' into capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_ophys_nwb_12_32
+	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_pipeline_processing_metadata_aggregator_11_21
+	path 'capsule/results/*/events/*.h5' into capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_ophys_nwb_12_33
 
 	script:
 	"""
@@ -352,17 +355,17 @@ process capsule_aind_ophys_oasis_event_detection_9 {
 // capsule - aind-ophys-mesoscope-image-splitter
 process capsule_aind_ophys_mesoscope_image_splitter_10 {
 	tag 'capsule-0115380'
-	container "$REGISTRY_HOST/capsule/c567666c-dd08-45dd-a824-6a570bd4675d:43a670fd4eacc08b5a31923b9dcbd449"
+	container "$REGISTRY_HOST/capsule/c567666c-dd08-45dd-a824-6a570bd4675d"
 
 	cpus 16
 	memory '128 GB'
 
 	input:
-	path 'capsule/data' from ophys_mount_to_aind_ophys_mesoscope_image_splitter_18.collect()
+	path 'capsule/data' from ophys_mount_to_aind_ophys_mesoscope_image_splitter_19.collect()
 
 	output:
 	path 'capsule/results/*_[0-9]' into capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_motion_correction_1_4
-	path 'capsule/results/*/V*_[0-9].h5' into capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_decrosstalk_roi_images_3_8
+	path 'capsule/results/*/*' into capsule_aind_ophys_mesoscope_image_splitter_10_to_capsule_aind_ophys_decrosstalk_roi_images_3_9
 
 	script:
 	"""
@@ -404,13 +407,13 @@ process capsule_aind_pipeline_processing_metadata_aggregator_11 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from capsule_aind_ophys_classifier_17_to_capsule_aind_pipeline_processing_metadata_aggregator_11_19.collect()
-	path 'capsule/data/' from capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_pipeline_processing_metadata_aggregator_11_20.collect()
-	path 'capsule/data/' from capsule_aind_ophys_dff_5_to_capsule_aind_pipeline_processing_metadata_aggregator_11_21.collect()
-	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_pipeline_processing_metadata_aggregator_11_22.collect()
-	path 'capsule/data/' from capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_pipeline_processing_metadata_aggregator_11_23.collect()
-	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_pipeline_processing_metadata_aggregator_11_24.collect()
-	path 'capsule/data/' from ophys_mount_to_aind_pipeline_processing_metadata_aggregator_25.collect()
+	path 'capsule/data/' from capsule_aind_ophys_classifier_17_to_capsule_aind_pipeline_processing_metadata_aggregator_11_20.collect()
+	path 'capsule/data/' from capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_pipeline_processing_metadata_aggregator_11_21.collect()
+	path 'capsule/data/' from capsule_aind_ophys_dff_5_to_capsule_aind_pipeline_processing_metadata_aggregator_11_22.collect()
+	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_pipeline_processing_metadata_aggregator_11_23.collect()
+	path 'capsule/data/' from capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_pipeline_processing_metadata_aggregator_11_24.collect()
+	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_pipeline_processing_metadata_aggregator_11_25.collect()
+	path 'capsule/data/' from ophys_mount_to_aind_pipeline_processing_metadata_aggregator_26.collect()
 
 	output:
 	path 'capsule/results/*'
@@ -454,18 +457,18 @@ process capsule_aind_ophys_nwb_12 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/processed/' from capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_nwb_12_26.collect()
-	path 'capsule/data/processed/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_27.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_nwb_12_27.collect()
 	path 'capsule/data/processed/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_28.collect()
 	path 'capsule/data/processed/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_29.collect()
 	path 'capsule/data/processed/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_30.collect()
-	path 'capsule/data/multiplane-ophys_raw' from ophys_mount_to_aind_ophys_nwb_31.collect()
-	path 'capsule/data/processed/' from capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_ophys_nwb_12_32.collect()
-	path 'capsule/data/processed/' from capsule_aind_ophys_dff_5_to_capsule_aind_ophys_nwb_12_33.collect()
-	path 'capsule/data/processed/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_34.collect()
-	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_35.collect()
-	path 'capsule/data/processed/' from capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_nwb_12_36.collect()
-	path 'capsule/data/nwb/' from capsule_nwb_packaging_subject_capsule_13_to_capsule_aind_ophys_nwb_12_37.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_nwb_12_31.collect()
+	path 'capsule/data/multiplane-ophys_raw' from ophys_mount_to_aind_ophys_nwb_32.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_oasis_event_detection_9_to_capsule_aind_ophys_nwb_12_33.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_dff_5_to_capsule_aind_ophys_nwb_12_34.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_35.collect()
+	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_nwb_12_36.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_decrosstalk_roi_images_3_to_capsule_aind_ophys_nwb_12_37.collect()
+	path 'capsule/data/nwb/' from capsule_nwb_packaging_subject_capsule_13_to_capsule_aind_ophys_nwb_12_38.collect()
 
 	output:
 	path 'capsule/results/*'
@@ -509,10 +512,10 @@ process capsule_nwb_packaging_subject_capsule_13 {
 	memory '8 GB'
 
 	input:
-	path 'capsule/data/ophys_session' from ophys_mount_to_nwb_packaging_subject_capsule_38.collect()
+	path 'capsule/data/ophys_session' from ophys_mount_to_nwb_packaging_subject_capsule_39.collect()
 
 	output:
-	path 'capsule/results/*' into capsule_nwb_packaging_subject_capsule_13_to_capsule_aind_ophys_nwb_12_37
+	path 'capsule/results/*' into capsule_nwb_packaging_subject_capsule_13_to_capsule_aind_ophys_nwb_12_38
 
 	script:
 	"""
@@ -553,7 +556,7 @@ process capsule_aind_ophys_movie_qc_15 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_movie_qc_15_39.flatten()
+	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_movie_qc_15_40.flatten()
 
 	output:
 	path 'capsule/results/*'
@@ -597,8 +600,8 @@ process capsule_aind_ophys_quality_control_aggregator_16 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/processed/' from capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_quality_control_aggregator_16_40.collect()
-	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_quality_control_aggregator_16_41.collect()
+	path 'capsule/data/processed/' from capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_quality_control_aggregator_16_41.collect()
+	path 'capsule/data/' from capsule_aind_ophys_motion_correction_1_to_capsule_aind_ophys_quality_control_aggregator_16_42.collect()
 
 	output:
 	path 'capsule/results/*'
@@ -644,13 +647,13 @@ process capsule_aind_ophys_classifier_17 {
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
 	input:
-	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_classifier_17_42
-	path 'capsule/data/' from ophys_mount_to_aind_ophys_classifier_43.collect()
+	path 'capsule/data/' from capsule_aind_ophys_extraction_suite_2_p_4_to_capsule_aind_ophys_classifier_17_43
+	path 'capsule/data/' from ophys_mount_to_aind_ophys_classifier_44.collect()
 
 	output:
-	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_classifier_17_to_capsule_aind_pipeline_processing_metadata_aggregator_11_19
-	path 'capsule/results/*/classification/*classification.h5' into capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_nwb_12_26
-	path 'capsule/results/*/classification/*classification.h5' into capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_quality_control_aggregator_16_40
+	path 'capsule/results/*/*/*data_process.json' into capsule_aind_ophys_classifier_17_to_capsule_aind_pipeline_processing_metadata_aggregator_11_20
+	path 'capsule/results/*/classification/*classification.h5' into capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_nwb_12_27
+	path 'capsule/results/*/classification/*classification.h5' into capsule_aind_ophys_classifier_17_to_capsule_aind_ophys_quality_control_aggregator_16_41
 	path 'capsule/results/*'
 
 	script:

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -1,5 +1,5 @@
 #!/usr/bin/env nextflow
-// hash:sha256:af47b618aedc2320c5dfb3ee251ea3df07631603fffa0e72bc5c51606030e467
+// hash:sha256:d6c674cf8e3330558fb4328b9ebb60cfe6e20450bbabe80301afecb4a1dba8c7
 
 nextflow.enable.dsl = 1
 
@@ -398,8 +398,8 @@ process capsule_aind_pipeline_processing_metadata_aggregator_11 {
 	tag 'capsule-8250608'
 	container "$REGISTRY_HOST/published/d51df783-d892-4304-a129-238a9baea72a:v4"
 
-	cpus 4
-	memory '32 GB'
+	cpus 2
+	memory '16 GB'
 
 	publishDir "$RESULTS_PATH", saveAs: { filename -> new File(filename).getName() }
 
@@ -421,8 +421,8 @@ process capsule_aind_pipeline_processing_metadata_aggregator_11 {
 	set -e
 
 	export CO_CAPSULE_ID=d51df783-d892-4304-a129-238a9baea72a
-	export CO_CPUS=4
-	export CO_MEMORY=34359738368
+	export CO_CPUS=2
+	export CO_MEMORY=17179869184
 
 	mkdir -p capsule
 	mkdir -p capsule/data && ln -s \$PWD/capsule/data /data


### PR DESCRIPTION
- Merges split vs non-split input optical physiology movies
- `aind-ophys-mesoscope-image-splitter`: provides logic to bypass split inputs
- `aind-ophys-motion-correction`: option to read h5 file from text input (bypassed output of the splitter)
- `aind-ophys-decrosstalk-roi-images`: general, recursive glob for unregistered `.h5` file